### PR TITLE
Add log command functionality

### DIFF
--- a/lambda/scarsupervisor.py
+++ b/lambda/scarsupervisor.py
@@ -66,6 +66,12 @@ def get_global_variables():
             cont_variables.append(key.replace("CONT_VAR_", "")+'='+os.environ[key])
     return cont_variables
 
+def prepare_output(context):
+    stdout = "SCAR: Log group name: " + context.log_group_name + "\n"
+    stdout += "SCAR: Log stream name: " + context.log_stream_name + "\n"
+    stdout += "---------------------------------------------------------------------------\n"
+    return stdout
+
 def lambda_handler(event, context):
     print("SCAR: Received event: " + json.dumps(event, indent=2))
     file_retriever = urllib.URLopener()
@@ -88,6 +94,8 @@ def lambda_handler(event, context):
     
     # Execute script
     call(command, stderr = STDOUT, stdout = open(lambda_output,"w"))
-    stdout = "SCAR: Log group name: " + context.log_group_name + "\nSCAR: Log stream name: " + context.log_stream_name + "\n" + check_output(["cat", lambda_output])
+    
+    stdout = prepare_output(context)
+    stdout += check_output(["cat", lambda_output])
     print stdout    
     return stdout


### PR DESCRIPTION
The log command returns the logs for the group name and stream name specified.
If a request_id is specified returns only the logs for such request.
Due to $ value in the log stream name the parameter must be enclosed with quotes.
Usage: 
 - ./scar log /aws/lambda/test '2017/05/29/[$LATEST]c103e98a56f747ddaea6139dfe44234a'  -> returns all the log stream
-  ./scar log /aws/lambda/test '2017/05/29/[$LATEST]c103e98a56f747ddaea6139dfe44234a' -ri bac40a28-447d-11e7-951c-db21c480za37 -> returns the logs for the request id specified

Also update output for run command