### PR TITLE
Slimmed down MrBayes Dockerfile

### DIFF
--- a/examples/mrbayes/Dockerfile
+++ b/examples/mrbayes/Dockerfile
@@ -9,27 +9,15 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     automake \ 
     libtool \
-    subversion \
-    pkg-config \
-    openjdk-6-jdk \
-    git \
-    wget \
-    openmpi-bin \
-    openmpi-doc \
-    libopenmpi-dev
-
-RUN git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git && \
-    cd beagle-lib && \ 
-    ./autogen.sh && \
-    ./configure --prefix=/usr/local/ && \
-    make install
+    pkg-config \    
+    wget
 
 RUN wget http://sourceforge.net/projects/mrbayes/files/mrbayes/3.2.6/mrbayes-3.2.6.tar.gz -O /tmp/mrbayes-3.2.6.tar.gz && \
     cd /tmp && \
     tar zxvf mrbayes-3.2.6.tar.gz  && \
     cd /tmp/mrbayes-3.2.6/src && \
     autoconf && \
-    ./configure --enable-mpi=yes && \
+    ./configure --with-beagle=no && \
     make && \
     make install
 


### PR DESCRIPTION
Removed Beagle and, therefore, Java JDK in an attempt to reduce the
resulting Docker image size.