### PR TITLE
Fix bug and timeout

### DIFF
--- a/lambda/scarsupervisor.py
+++ b/lambda/scarsupervisor.py
@@ -146,7 +146,8 @@ class Supervisor():
             command.extend(["--entrypoint=%s %s" % (script_exec, script), Supervisor.container_name])
         # Container with args
         elif ('cmd_args' in event) and event['cmd_args']:
-            args = map(lambda x: x.encode('ascii'), event['cmd_args'])
+            # Parse list of strings
+            args = event['cmd_args'][1:-1].replace('"','').split(', ')
             command.append(Supervisor.container_name)
             command.extend(args)
         # Script to be executed every time (if defined)

--- a/scar.py
+++ b/scar.py
@@ -18,6 +18,7 @@
 import argparse
 import base64
 import boto3
+import botocore
 import configparser
 import json
 import os
@@ -486,6 +487,7 @@ class Config(object):
                     ]}
 
     version = "v1.0.0"
+    botocore_client_read_timeout=360
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -571,7 +573,8 @@ class AwsClient(object):
     def get_boto3_client(self, client_name, region=None):
         if region is None:
             region = Config.lambda_region
-        return boto3.client(client_name, region_name=region)
+        config = botocore.config.Config(read_timeout=Config.botocore_client_read_timeout)            
+        return boto3.client(client_name, region_name=region, config=config)
 
     def get_lambda(self, region=None):
         return self.get_boto3_client('lambda', region)

--- a/test/unit/TestAwsClient.py
+++ b/test/unit/TestAwsClient.py
@@ -51,12 +51,14 @@ class TestAwsClient(unittest.TestCase):
         self.assertEqual(300, AwsClient().check_time(300))
         self.assertEqual(147, AwsClient().check_time(147))
 
+    @unittest.mock.patch('botocore.config.Config')
     @unittest.mock.patch('boto3.client')        
-    def test_get_user_name_or_id(self, mock_client):
+    def test_get_user_name_or_id(self, mock_client, mock_config):
         mock_client.return_value.get_user.return_value = {'User' : { 'UserName' : 'test1', 'UserId' : 'asd123' }}
+        mock_config.return_value='config'
         user = AwsClient().get_user_name_or_id()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('iam', region_name='us-east-1'))       
+        self.assertEqual(mock_client.call_args, call('iam', config='config', region_name='us-east-1'))       
         self.assertTrue(call().get_user() in mock_client.mock_calls)
         self.assertEqual(user, 'test1')
 
@@ -75,47 +77,61 @@ class TestAwsClient(unittest.TestCase):
         access_key = AwsClient().get_access_key()
         self.assertEqual(access_key, 'test')
         
+    @unittest.mock.patch('botocore.config.Config')       
     @unittest.mock.patch('boto3.client')
-    def test_get_boto3_client_no_region(self, mock_client):
+    def test_get_boto3_client_no_region(self, mock_client, mock_config):
+        mock_config.return_value = 'config'        
         AwsClient().get_boto3_client('test')
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('test', region_name='us-east-1'))
+        self.assertEqual(mock_client.call_args, call('test', config='config', region_name='us-east-1'))
         
+    @unittest.mock.patch('botocore.config.Config')       
     @unittest.mock.patch('boto3.client')
-    def test_get_boto3_client(self, mock_client):
+    def test_get_boto3_client(self, mock_client, mock_config):
+        mock_config.return_value = 'config'        
         AwsClient().get_boto3_client('test', 'test-region')
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('test', region_name='test-region'))
+        self.assertEqual(mock_client.call_args, call('test', config='config', region_name='test-region'))
 
+    @unittest.mock.patch('botocore.config.Config')       
     @unittest.mock.patch('boto3.client')
-    def test_get_lambda(self, mock_client):
+    def test_get_lambda(self, mock_client, mock_config):
+        mock_config.return_value = 'config'        
         AwsClient().get_lambda()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('lambda', region_name='us-east-1'))
+        self.assertEqual(mock_client.call_args, call('lambda', config='config', region_name='us-east-1'))
 
+    @unittest.mock.patch('botocore.config.Config')       
     @unittest.mock.patch('boto3.client')
-    def test_get_log(self, mock_client):
+    def test_get_log(self, mock_client, mock_config):
+        mock_config.return_value = 'config'
         AwsClient().get_log()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('logs', region_name='us-east-1'))
-        
+        self.assertEqual(mock_client.call_args, call('logs', config='config', region_name='us-east-1'))
+ 
+    @unittest.mock.patch('botocore.config.Config')       
     @unittest.mock.patch('boto3.client')
-    def test_get_iam(self, mock_client):
+    def test_get_iam(self, mock_client, mock_config):
+        mock_config.return_value = 'config'
         AwsClient().get_iam()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('iam', region_name='us-east-1'))
+        self.assertEqual(mock_client.call_args, call('iam', config='config', region_name='us-east-1'))
 
+    @unittest.mock.patch('botocore.config.Config')
     @unittest.mock.patch('boto3.client')
-    def test_get_resource_groups_tagging_api(self, mock_client):
+    def test_get_resource_groups_tagging_api(self, mock_client, mock_config):
+        mock_config.return_value = 'config'        
         AwsClient().get_resource_groups_tagging_api()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('resourcegroupstaggingapi', region_name='us-east-1'))
+        self.assertEqual(mock_client.call_args, call('resourcegroupstaggingapi', config='config', region_name='us-east-1'))
 
+    @unittest.mock.patch('botocore.config.Config')
     @unittest.mock.patch('boto3.client')
-    def test_get_s3(self, mock_client):
+    def test_get_s3(self, mock_client, mock_config):
+        mock_config.return_value = 'config'        
         AwsClient().get_s3()
         self.assertEqual(mock_client.call_count, 1)
-        self.assertEqual(mock_client.call_args, call('s3', region_name='us-east-1'))
+        self.assertEqual(mock_client.call_args, call('s3', config='config', region_name='us-east-1'))
 
     @unittest.mock.patch('scar.AwsClient.get_s3')
     def test_get_s3_file_list(self, mock_s3_client): 


### PR DESCRIPTION
Fix bug in scarsupervisor. The commands passed to the container were not parsed correctly.
Fix botocore client timeout. The new read timeout is set to 360s.