### PR TITLE
Add 'lambda_output' parameter

### DIFF
--- a/src/parser/cli.py
+++ b/src/parser/cli.py
@@ -59,6 +59,7 @@ class CommandParser(object):
         parser_init.add_argument("-r", "--recursive", help="Launch a recursive lambda function", action="store_true")
         parser_init.add_argument("-p", "--preheat", help="Preheats the function running it once and downloading the necessary container", action="store_true")
         parser_init.add_argument("-ep", "--extra_payload", help="Folder containing files that are going to be added to the lambda function")
+        parser_init.add_argument("-lo", "--lambda_output", help="Lambda function name where the output will be redirected")
     
     def create_run_parser(self):
         parser_run = self.subparsers.add_parser('run', help="Deploy function")

--- a/src/providers/aws/client/lambdafunction.py
+++ b/src/providers/aws/client/lambdafunction.py
@@ -110,6 +110,9 @@ class Lambda(object):
     def has_event_source(self):
         return self.get_property("event_source") != ""
     
+    def has_lambda_output(self):
+        return self.get_property("lambda_output") != ""    
+    
     def get_event_source(self):
         return self.get_property("event_source")   
     
@@ -275,6 +278,8 @@ class Lambda(object):
         self.set_env_var('TIMEOUT_THRESHOLD', str(self.get_property("timeout_threshold")))
         self.set_env_var('RECURSIVE', str(self.get_property("recursive")))
         self.set_env_var('IMAGE_ID', self.get_property("image_id"))
+        if self.has_lambda_output():
+            self.set_env_var('LAMBDA_OUTPUT', self.get_property("lambda_output")) 
 
     def set_environment_variables(self):
         if isinstance(self.get_property("environment_variables"), list):

--- a/src/providers/aws/controller.py
+++ b/src/providers/aws/controller.py
@@ -61,6 +61,7 @@ class AWS(Commands):
         
         if self._lambda.has_event_source():
             self.create_event_source()
+
         # If preheat is activated, the function is launched at the init step
         if self._lambda.need_preheat():    
             self._lambda.preheat_function()


### PR DESCRIPTION
Now you can pass an specified output to another lambda function.
It is set like this:
`scar init -n test-caller -lo test-called -i ubuntu`

Inside the ubuntu container an environment variable called `LAMBDA_OUTPUT_FILE` is created. This variable stores the path of the file that will be passed to the `test-called` function.
Inside the container your script must write in this file whatever you want to pass to the called function.