### PR TITLE
Add missing property in scar cfg

### DIFF
--- a/src/parser/cfgfile.py
+++ b/src/parser/cfgfile.py
@@ -29,7 +29,8 @@ default_cfg = {
           "time" : 300,
           "memory" : 512,
           "description" : "Automatically generated lambda function",
-          "timeout_threshold" : 10 
+          "timeout_threshold" : 10 ,
+          "runtime" : "python3.6"
         },
         "cloudwatch" : { "log_retention_policy_in_days" : 30 }
     }


### PR DESCRIPTION
- Add missing `runtime` property