### PR TITLE
pass down aws session token to container

### DIFF
--- a/src/providers/aws/cloud/lambda/scarsupervisor.py
+++ b/src/providers/aws/cloud/lambda/scarsupervisor.py
@@ -288,7 +288,8 @@ class Udocker():
     def get_iam_credentials(self):
         creds = []
         iam_creds = {'CONT_VAR_AWS_ACCESS_KEY_ID':'AWS_ACCESS_KEY_ID',
-                     'CONT_VAR_AWS_SECRET_ACCESS_KEY':'AWS_SECRET_ACCESS_KEY'}
+                     'CONT_VAR_AWS_SECRET_ACCESS_KEY':'AWS_SECRET_ACCESS_KEY',
+                     'CONT_VAR_AWS_SESSION_TOKEN':'AWS_SESSION_TOKEN'}
         # Add IAM credentials
         for key,value in iam_creds.items():
             if not utils.is_variable_in_environment(key):


### PR DESCRIPTION
Hey there 👋 

Some internal aws functions (aws-cli) need the $AWS_SESSION_TOKEN environment variable. This was not being passed down to our container which would result in the following error when running aws-cli kms functionality - 

```
ClientError: An error occurred (UnrecognizedClientException) when calling the Decrypt operation: The security token included in the request is invalid
```

This functionality originally was here https://github.com/grycap/scar/pull/107 but has seemed to be removed on further refactors. 

Please let me know if you need anything more from me to get this merged! Great project!