### PR TITLE
add support to use kms to use encrypted environment variables

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -92,12 +92,26 @@ or::
 
   scar update -e EST1: 145 -e TEST2: i69 -e TEST2: 42 -n scar-cowsay  
 
+
+Also, you can specify encrypted variables here. If SCAR detects an encrypted value, it will attempt to use AWS KMS to decrypt it and add it to the executed Docker container. It does this by looking for the "KMS_ENC" prefix on a user defined environment variable. In the Docker container, the variable prefix will be renamed to "KMS_DEC"::
+
+  cat >> env-var.yaml << EOF
+  functions:
+    scar-cowsay:
+      image: grycap/cowsay
+      init_script: src/test/test-global-vars.sh
+      environment:
+        KMS_ENC_TEST1: ASSDKDJSKDJSENCRYPTEDVALUE
+  EOF
+
+  scar init -f env-var.yaml
+
+
 In addition, the following environment variables are automatically made available to the underlying Docker container:
 
 * AWS_ACCESS_KEY_ID
 * AWS_SECRET_ACCESS_KEY
 * AWS_SESSION_TOKEN
-* AWS_SECURITY_TOKEN
 
 This allows a script running in the Docker container to access other AWS services. As an example, see how the AWS CLI runs on AWS Lambda in the `examples/aws-cli <https://github.com/grycap/scar/tree/master/examples/aws-cli>`_ folder.
 


### PR DESCRIPTION
Hi again 👋 

I have a use case where I wanted to use KMS to decrypt sign in credentials for the lastpass-cli tool. My first thought was using aws-cli to get our decrypted value on the fly. However, when adding the necessary packages needed to do this in my dockerfile (along with my other dependencies), I reached the Lambda memory limit. 

To reduce size, I decided to handle this inside of SCAR and inject our decrypted values in the container at run time, like we do with the other environment variables. 

This will take any container variable prefaced with `ENC`, use KMS to decrypt them and inject it in our container context, while renaming them with the prefix `DEC`

If this is functionality you are interested in, I'd be happy to clean this PR up, add some tests, and update documentation. Please let me know! Otherwise I'll stick with my fork, unless you have a better implementation pattern for this.

Thanks!
Jon