### PR TITLE
Add json support ag

### DIFF
--- a/docs/source/api_gateway.rst
+++ b/docs/source/api_gateway.rst
@@ -67,6 +67,9 @@ or::
 The file specified after the parameter ``-db`` is codified and passed as the POST body.
 Take into account that the file limitations for request response and asynchronous requests are 6MB and 128KB respectively, as specified in the `AWS lambda documentation <https://docs.aws.amazon.com/lambda/latest/dg/limits.html>`_.
 
+Lastly, You can also submit JSON as the body to the HTTP endpoint with no other configuration, as long Content-Type is application/json. If SCAR sees a JSON body, it will write this body to /tmp/{REQUEST_ID}/api_event.json. Otherwise, it will default the post body to it being a file.
+
+
 Passing parameters in the requests
 ----------------------------------
 

--- a/src/providers/aws/cloud/lambda/scarsupervisor.py
+++ b/src/providers/aws/cloud/lambda/scarsupervisor.py
@@ -115,20 +115,37 @@ class S3():
 #######################################
 
 class HTTP():
-    
+
     def is_post_request_with_body(self):
         return lambda_instance.event['httpMethod'] == 'POST' and lambda_instance.event['body'] is not None
-    
+
+    def is_post_request_with_body_json(self):
+        return lambda_instance.event['httpMethod'] == 'POST' and lambda_instance.event['headers']['Content-Type'].strip() == 'application/json'
+
+    def save_post_body_json(self):
+        body = lambda_instance.event['body']
+        file_path = "/tmp/{0}/api_event.json".format(lambda_instance.request_id)
+        logger.info("Received JSON from POST request and saved it in path '{0}'".format(file_path))
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)  
+        with open(file_path, 'w') as event_file:
+            event_file.write(body)
+        return file_path
+
+    def save_post_body_file(self):
+        body = base64.b64decode(lambda_instance.event['body'])
+        body_file_name = uuid.uuid4().hex
+        file_path = "/tmp/{0}/{1}".format(lambda_instance.request_id, body_file_name)
+        logger.info("Received file from POST request and saved it in path '{0}'".format(file_path))
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)  
+        with open(file_path, 'wb') as data:
+            data.write(body)
+        return file_path
+
     def save_post_body(self):
-        if self.is_post_request_with_body():
-            body = base64.b64decode(lambda_instance.event['body'])
-            body_file_name = uuid.uuid4().hex
-            file_path = "/tmp/{0}/{1}".format(lambda_instance.request_id, body_file_name)
-            logger.info("Received file from POST request and saved it in path '{0}'".format(file_path))
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)  
-            with open(file_path, 'wb') as data:
-                data.write(body)
-            return file_path
+        if self.is_post_request_with_body_json():
+            return self.save_post_body_json()
+        elif self.is_post_request_with_body:
+            return self.save_post_body_file()
 
 class Lambda():
 


### PR DESCRIPTION
Me again! Our integration with SCAR needed JSON body support for the API Gateway integration. Below is how I accomplished that. Thought I'd offer it up if this is something that you find to fit in SCARs programming model. 

I haven't made this available yet in the `scar invoke` CLI, but can do if you feel that this functionality should also exist there. To test, I've been using the API Gateway console with a test event. 
