### PR TITLE
ISSUE-354: Create ability to get config from environment

### DIFF
--- a/scar/parser/cfgfile.py
+++ b/scar/parser/cfgfile.py
@@ -147,6 +147,7 @@ class ConfigFileParser():
     _CONFIG_FOLDER_PATH = ".scar"
     _CONFIG_FILE_PATH = "scar.cfg"
     _CONFIG_FILE_NAME_BCK = "scar.cfg_old"
+    _CONFIG_FILE_NAME_TMP_YAML = "scar_tmp.yaml"
 
     # Set default config folder path
     config_file_folder = FileUtils.join_paths(SysUtils.get_user_home_path(), _CONFIG_FOLDER_PATH)
@@ -158,6 +159,7 @@ class ConfigFileParser():
     # Set config file paths
     config_file_path = FileUtils.join_paths(config_file_folder, _CONFIG_FILE_PATH)
     backup_file_path = FileUtils.join_paths(config_file_folder, _CONFIG_FILE_NAME_BCK)
+    tmp_yaml_file_path = FileUtils.join_paths(config_file_folder, _CONFIG_FILE_NAME_TMP_YAML)
 
     @exception(logger)
     def __init__(self):

--- a/scar/parser/cfgfile.py
+++ b/scar/parser/cfgfile.py
@@ -15,6 +15,7 @@
 of managing the SCAR configuration file."""
 
 import json
+import os
 from scar.exceptions import exception, ScarConfigFileError
 import scar.logger as logger
 from scar.utils import FileUtils, SysUtils, StrUtils
@@ -142,10 +143,19 @@ _DEFAULT_CFG = {
 class ConfigFileParser():
     """Class to manage the SCAR configuration file creation, update and load."""
 
+    _CONFIG_FOLDER_PATH_ENV_VAR = 'SCAR_CONFIG_FOLDER'
     _CONFIG_FOLDER_PATH = ".scar"
     _CONFIG_FILE_PATH = "scar.cfg"
     _CONFIG_FILE_NAME_BCK = "scar.cfg_old"
+
+    # Set default config folder path
     config_file_folder = FileUtils.join_paths(SysUtils.get_user_home_path(), _CONFIG_FOLDER_PATH)
+
+    # Check if config folder env var is set, and use it for config paths
+    if _CONFIG_FOLDER_PATH_ENV_VAR in os.environ:
+        config_file_folder = os.getenv(_CONFIG_FOLDER_PATH_ENV_VAR)
+
+    # Set config file paths
     config_file_path = FileUtils.join_paths(config_file_folder, _CONFIG_FILE_PATH)
     backup_file_path = FileUtils.join_paths(config_file_folder, _CONFIG_FILE_NAME_BCK)
 

--- a/scar/scarcli.py
+++ b/scar/scarcli.py
@@ -47,7 +47,7 @@ def parse_arguments():
         # CMD >> SCAR.CONF
         merged_args = fdl.merge_conf(config_args, cmd_args)
     #self.cloud_provider.parse_arguments(merged_args)
-    FileUtils.create_tmp_config_file(merged_args)
+    FileUtils.create_tmp_config_file(merged_args, ConfigFileParser())
     return func_call
 
 def main():

--- a/scar/utils.py
+++ b/scar/utils.py
@@ -304,8 +304,8 @@ class FileUtils:
             yaml.safe_dump(content, cfg_file)
 
     @staticmethod
-    def create_tmp_config_file(cfg_args):
-        cfg_path = FileUtils.join_paths(SysUtils.get_user_home_path(), ".scar", "scar_tmp.yaml")
+    def create_tmp_config_file(cfg_args, ConfigFileParser):
+        cfg_path = ConfigFileParser.tmp_yaml_file_path
         os.environ['SCAR_TMP_CFG'] = cfg_path
         FileUtils.write_yaml(cfg_path, cfg_args)
 


### PR DESCRIPTION
This PR ads the ability for the scar config to be determined from the environment variable `SCAR_CONFIG_FOLDER` as documented here: https://scar.readthedocs.io/en/latest/scar_container.html#building-the-scar-image

I needed this to switch config between projects. See #354 
